### PR TITLE
Update name extracted from master.zip

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,8 +12,8 @@ _fetch_sources(){
 
   cd ~/.nano/ || exit
   unzip -o "/tmp/nanorc.zip"
-  mv nanorc-master/* ./
-  rm -rf nanorc-master
+  mv nano-syntax-highlighting-master/* ./
+  rm -rf nano-syntax-highlighting-master
   rm /tmp/nanorc.zip
 }
 


### PR DESCRIPTION
The master.zip contains a folder "nano-syntax-highlighting-master" now in the fork where originally it extracted as "nanorc-master".

Somewhat related, is it an oversight or intentional decision to not have Issues activated on this repo? 👀 

````sh
[...]
mv: can't rename 'nanorc-master/*': No such file or directory

~/.nano $ ls -la
total 12
drwxr-xr-x    3 rf     rf          4096 Nov  7 17:21 .
drwx------    8 rf     rf          4096 Nov  7 17:21 ..
drwxrwxrwx    2 rf     rf          4096 Nov  7 17:21 nano-syntax-highlighting-master
```