### PR TITLE
fix(powershell): block comment in comment

### DIFF
--- a/powershell.nanorc
+++ b/powershell.nanorc
@@ -24,10 +24,9 @@ icolor brightcyan "\<(class|enum|function|using|assembly|command|module|namespac
 ## Types
 icolor green "\<(string|char|byte|int|long|bool|decimal|single|double|DateTime|xml|array|hashtable|void)\>"
 
-# TODO: This logic seems a bit off... look into this
 ## Comments
 color cyan start="<#" end="#>"
-color cyan "(^|[[:space:]])#[^>].*$"
+color cyan "(^|[[:space:]])#[^>]([^#]|#[^>])*$"
 
 ## Quoted text
 color brightyellow "\"[^\"]*\""


### PR DESCRIPTION
This fixes https://github.com/galenguyer/nano-syntax-highlighting/issues/5

The result: (see the description in the issue)

<img src=https://github.com/galenguyer/nano-syntax-highlighting/assets/23246033/ec03976a-cb80-467a-8d51-acd2c4d4d657 width=60%>

