### PR TITLE
fix: Force all syntax regex to ends with `$`

### DIFF
--- a/Rnw.nanorc
+++ b/Rnw.nanorc
@@ -1,6 +1,6 @@
 ## Here is a short example for TeX files.
 ##
-syntax "Tex" "\.Rnw$" "bib" "\.bib$" "cls" "\.cls$"
+syntax "Tex" "\.Rnw$" "bib$" "\.bib$" "cls$" "\.cls$"
 color yellow "\$(\\\$|[^$])*[^\\]\$"
 color yellow "\$\$(\\\$|[^$])*[^\\]\$\$"
 icolor green "\\.|\\[A-Z]*"

--- a/apacheconf.nanorc
+++ b/apacheconf.nanorc
@@ -1,5 +1,5 @@
 # Apache files
-syntax "Apacheconf" "httpd\.conf|mime\.types|vhosts\.d\\*|\.htaccess"
+syntax "Apacheconf" "(httpd\.conf|mime\.types|vhosts\.d\\*|\.htaccess)$"
 color yellow ".+"
 color brightcyan "(AcceptMutex|AcceptPathInfo|AccessFileName|Action|AddAlt|AddAltByEncoding|AddAltByType|AddCharset|AddDefaultCharset|AddDescription|AddEncoding)"
 color brightcyan "(AddHandler|AddIcon|AddIconByEncoding|AddIconByType|AddInputFilter|AddLanguage|AddModuleInfo|AddOutputFilter|AddOutputFilterByType|AddType|Alias|AliasMatch)"

--- a/beancount.nanorc
+++ b/beancount.nanorc
@@ -1,4 +1,4 @@
-syntax "Beancount" "(^|\.|/)beancount|bnct|bc$"
+syntax "Beancount" "(^|\.|/)(beancount|bnct|bc)$"
 
 # directives
 color red "^([0-9]{4}-[0-9]{2}-[0-9]{2} | )?[a-z-]+( |: )"

--- a/c.nanorc
+++ b/c.nanorc
@@ -1,6 +1,6 @@
 ## Here is an example for C/C++.
 ##
-syntax "C" "\.(c(c|pp|xx)?|C)$" "\.(h(h|pp|xx)?|H)$" "\.ii?$" "\.(def)$" "\.ino"
+syntax "C" "\.(c(c|pp|xx)?|C)$" "\.(h(h|pp|xx)?|H)$" "\.ii?$" "\.(def)$" "\.ino$"
 magic "^(C|C\+\+) (source|program)"
 comment "//"
 color brightred "\<[A-Z_][0-9A-Z_]+\>"

--- a/clojure.nanorc
+++ b/clojure.nanorc
@@ -1,7 +1,7 @@
 ## Clojure Syntax Highlighting
 ##
 
-syntax "clojure" "\.((clj[s|c]?)|edn)"
+syntax "clojure" "\.((clj[s|c]?)|edn)$"
 
 icolor green "defn? [0-9A-Z_]+"
 

--- a/conky.nanorc
+++ b/conky.nanorc
@@ -2,7 +2,7 @@
 ## Syntax highlighting for conkyrc files.
 ##
 ##
-syntax "Conky" "(\.*conkyrc.*$|conky.conf)"
+syntax "Conky" "(\.*conkyrc.*|conky.conf)$"
 
 ## Configuration items
 color green "\<(alignment|append_file|background|border_inner_margin|border_outer_margin|border_width|color0|color1|color2|color3|color4|color5|color6|color7|color8|color9|colorN|cpu_avg_samples|default_bar_height|default_bar_width|default_color|default_gauge_height|default_gauge_width|default_graph_height|default_graph_width|default_outline_color|default_shade_color|diskio_avg_samples|display|double_buffer|draw_borders|draw_graph_borders|draw_outline|draw_shades|extra_newline|font|format_human_readable|gap_x|gap_y|http_refresh|if_up_strictness|imap|imlib_cache_flush_interval|imlib_cache_size|lua_draw_hook_post|lua_draw_hook_pre|lua_load|lua_shutdown_hook|lua_startup_hook|mail_spool|max_port_monitor_connections|max_text_width|max_user_text|maximum_width|minimum_height|minimum_width|mpd_host|mpd_password|mpd_port|music_player_interval|mysql_host|mysql_port|mysql_user|mysql_password|mysql_db|net_avg_samples|no_buffers|nvidia_display|out_to_console|out_to_http|out_to_ncurses|out_to_stderr|out_to_x|override_utf8_locale|overwrite_file|own_window|own_window_class|own_window_colour|own_window_hints|own_window_title|own_window_transparent|own_window_type|pad_percents|pop3|sensor_device|short_units|show_graph_range|show_graph_scale|stippled_borders|temperature_unit|template|template0|template1|template2|template3|template4|template5|template6|template7|template8|template9|text|text_buffer_size|times_in_seconds|top_cpu_separate|top_name_width|total_run_times|update_interval|update_interval_on_battery|uppercase|use_spacer|use_xft|xftalpha|xftfont)\>"

--- a/csh.nanorc
+++ b/csh.nanorc
@@ -1,6 +1,6 @@
 ## Here is an example for c-shell scripts.
 ##
-syntax "CSH" "\.csh$" "\.tcshrc" "\.cshrc" "\.login" "\.logout" "\.history"
+syntax "CSH" "\.csh$" "\.tcshrc$" "\.cshrc$" "\.login$" "\.logout$" "\.history$"
 header "^#!.*/(env +)?(t)?csh( |$)"
 
 color green "\<(break|breaksw|case|continue|default|else|end|endif|endsw|exec|exit|foreach|goto|if|repeat|shift|switch|then|while)\>"

--- a/dotenv.nanorc
+++ b/dotenv.nanorc
@@ -2,7 +2,7 @@
 ## 
 ## Derived from sh.nanorc
 ##
-syntax "dotenv" "\.env" "\.env\..+"
+syntax "dotenv" "\.env$" "^\.env\..+$"
 
 color green "(\(|\)|\$|=)"
 color brightyellow ""(\\.|[^"])*"" "'(\\.|[^'])*'"

--- a/git.nanorc
+++ b/git.nanorc
@@ -50,7 +50,7 @@ color ,green "[[:space:]]+$"
 
 
 # This syntax format is used for interactive rebasing
-syntax "git-rebase-todo" "git-rebase-todo"
+syntax "git-rebase-todo" "git-rebase-todo$"
 
 # Default
 color yellow ".*"

--- a/groff.nanorc
+++ b/groff.nanorc
@@ -1,6 +1,6 @@
 ## Here is an example for groff.
 ##
-syntax "Groff" "\.m[ems]$" "\.rof" "\.tmac$" "^tmac."
+syntax "Groff" "\.m[ems]$" "\.rof$" "\.tmac$" "^tmac."
 comment ".\""
 
 ## The argument of .ds or .nr

--- a/i3.nanorc
+++ b/i3.nanorc
@@ -1,6 +1,6 @@
 ## Here is an example for i3 Window Manager config
 ##
-syntax "i3" "i3/config"
+syntax "i3" "i3/config$"
 header "^(.*)i3 config file"
 
 color green "\<(case|do|done|elif|else|esac|exit|fi|for|function|if|in|local|read|return|select|shift|then|time|until|while)\>"

--- a/ledger.nanorc
+++ b/ledger.nanorc
@@ -1,4 +1,4 @@
-syntax "Ledger" "(^|\.|/)ledger|ldgr|lg$"
+syntax "Ledger" "(^|\.|/)(ledger|ldgr|lg)$"
 
 # descriptions
 color brightmagenta "^(([0-9]{4}(/|-|.))?[0-9]{2}(/|-|.)[0-9]{2}|[=~]) .*"

--- a/perl6.nanorc
+++ b/perl6.nanorc
@@ -2,7 +2,7 @@
 ## Hybrid perl5 / perl6 syntax highlighting
 ### Found in CPAN - http://cpansearch.perl.org/src/NIGE/Goo-0.09/lib/.gooskel/nanorc
 
-syntax "Perl6" "\.p6$" "\.pl6$" "\.pm6"
+syntax "Perl6" "\.p6$" "\.pl6$" "\.pm6$"
 color brightblue "\<(accept|alarm|atan2|bin(d|mode)|c(aller|h(dir|mod|op|own|root)|lose(dir)?|onnect|os|rypt)|d(bm(close|open)|efined|elete|ie|o|ump)|e(ach|of|val|x(ec|ists|it|p))|f(cntl|ileno|lock|ork)|get(c|login|peername|pgrp|ppid|priority|pwnam|(host|net|proto|serv)byname|pwuid|grgid|(host|net)byaddr|protobynumber|servbyport)|([gs]et|end)(pw|gr|host|net|proto|serv)ent|getsock(name|opt)|gmtime|goto|grep|hex|index|int|ioctl|join|keys|kill|last|length|link|listen|local(time)?|log|lstat|m|mkdir|msg(ctl|get|snd|rcv)|next|oct|open(dir)?|ord|pack|pipe|pop|printf?|push|q|qq|qx|rand|re(ad(dir|link)?|cv|do|name|quire|set|turn|verse|winddir)|rindex|rmdir|s|scalar|seek|seekdir|se(lect|mctl|mget|mop|nd|tpgrp|tpriority|tsockopt)|shift|shm(ctl|get|read|write)|shutdown|sin|sleep|socket(pair)?|sort|spli(ce|t)|sprintf|sqrt|srand|stat|study|substr|symlink|sys(call|read|tem|write)|tell(dir)?|time|tr|y|truncate|umask|un(def|link|pack|shift)|utime|values|vec|wait(pid)?|wantarray|warn|write)\>"
 color brightblue "\<(continue|else|elsif|do|for|foreach|if|unless|until|while|eq|ne|lt|gt|le|ge|cmp|x|my|sub|use|package|can|isa)\>"
 

--- a/prolog.nanorc
+++ b/prolog.nanorc
@@ -1,6 +1,6 @@
 ## Here is a prolog example.
 
-syntax "prolog" "\.pl"
+syntax "prolog" "\.pl$"
 comment "%"
 
 # Reset everything

--- a/rego.nanorc
+++ b/rego.nanorc
@@ -1,6 +1,6 @@
 # Syntax highlighting for Rego (https://www.openpolicyagent.org/)
 
-syntax "Rego" "\.rego"
+syntax "Rego" "\.rego$"
 comment "#"
 
 ## Reserved words

--- a/ruby.nanorc
+++ b/ruby.nanorc
@@ -1,6 +1,6 @@
 ## Here is an example for Ruby.
 ##
-syntax "Ruby" "\.rb$" "Gemfile" "config.ru" "Rakefile" "Capfile" "Vagrantfile"
+syntax "Ruby" "\.rb$" "Gemfile$" "config.ru$" "Rakefile$" "Capfile$" "Vagrantfile$"
 header "^#!.*/(env +)?ruby( |$)"
 magic "Ruby script"
 linter ruby -w -c

--- a/rust.nanorc
+++ b/rust.nanorc
@@ -4,7 +4,7 @@
 # NOTE: Rules are applied in order: later rules re-colorize matching text.
 
 
-syntax "Rust" "\.rs"
+syntax "Rust" "\.rs$"
 comment "//"
 
 # function definition

--- a/sh.nanorc
+++ b/sh.nanorc
@@ -1,6 +1,6 @@
 ## Here is an example for Bourne shell scripts.
 ##
-syntax "SH" "\.sh$" "\.ash" "\.bashrc" "bashrc" "\.bash_aliases" "bash_aliases" "\.bash_functions" "bash_functions" "\.bash_login" "\.bash_logout" "\.bash_profile" "bash_profile" "\.profile" "revise\..+$"
+syntax "SH" "\.sh$" "\.ash$" "\.bashrc$" "bashrc$" "\.bash_aliases$" "bash_aliases$" "\.bash_functions$" "bash_functions$" "\.bash_login$" "\.bash_logout$" "\.bash_profile$" "bash_profile$" "\.profile$" "revise\..+$"
 header "^#!.*/(env +)?(ba|da|a)?sh( |$)"
 magic "(POSIX|Bourne-Again) shell script.*text"
 comment "#"

--- a/vi.nanorc
+++ b/vi.nanorc
@@ -1,4 +1,4 @@
-syntax "VI" "(^|/|\.)(ex|vim)rc$|\.vim"
+syntax "VI" "(^|/|\.)(ex|vim)rc$" "\.vim$"
 
 color brightblue "[A-Za-z_][A-Za-z0-9_]*[[:space:]]*[()]"
 color cyan  "\<([nvxsoilc]?(nore|un)?map|[nvlx]n|[ico]?no|[cilovx][um]|s?unm)\>"


### PR DESCRIPTION
## Description

Lots of syntax regex are poorly written and did not ends with a `$`, which caused them competing with other regex rules.

As a real example: I have a patch file named `0001-some-commit-that-enhanced-a-bashrc-file.patch`. Since it is ending with a `.patch`, one would expects it be highlighted using `patch.nanorc`. However, it turned out that `sh.nanorc` highlighted it (terribly, of course), just because of its poorly written regex!
