### PR TITLE
enh(install): Use defined constant as path

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -18,8 +18,8 @@ _fetch_sources(){
 }
 
 _update_nanorc(){
-  touch ~/.nanorc
-      
+  touch $NANORC_FILE
+
   # add all includes from ~/.nano/nanorc if they're not already there
   while read -r inc; do
       if ! grep -q "$inc" "${NANORC_FILE}"; then
@@ -45,7 +45,7 @@ case "$1" in
 esac
 
 _fetch_sources;
-if [ $UPDATE_LITE ];
+if [ "$UPDATE_LITE" ];
 then
   _update_nanorc_lite
 else


### PR DESCRIPTION
Change "~/.nanorc" to already defined constant $NANORC_FILE