### PR TITLE
fix(godot): empty string in 'header'

### DIFF
--- a/godot.nanorc
+++ b/godot.nanorc
@@ -1,7 +1,6 @@
 ## Syntax highlighting for Godot.
 
 syntax gdscript "\.gd$"
-header ""
 magic "Godot script"
 comment "#"
 


### PR DESCRIPTION
This fix https://github.com/galenguyer/nano-syntax-highlighting/issues/20