### PR TITLE
fix(elixir): string interpolation highlighted as comment

### DIFF
--- a/elixir.nanorc
+++ b/elixir.nanorc
@@ -29,16 +29,16 @@ color brightmagenta "~[a-z]\/([^\/])*\/[a-z]*" "~[a-z]\|([^\|])*\|[a-z]*" "~[a-z
 ## Strings, double-quoted
 color green ""([^"]|(\\"))*""
 
-## Expression substitution.  These go inside double-quoted strings,
-## "like #{this}".
-color brightgreen "#\{[^}]*\}"
-
 ## Strings, single-quoted
 color green "'([^']|(\\'))*'"
 
+## Expression substitution.  These go inside double-quoted strings,
+## "like #{this}".
+color normal "#\{[^}]*\}"
+
 ## Comments
-color cyan "#.*$" "#$"
-color brightcyan "##.*$" "##$"
+color cyan "(^|[[:space:]])#([^{].*|)$"
+color brightcyan "(^|[[:space:]])##.*$"
 
 ## "Here" docs
 color green start="\"\"\"" end="\"\"\""


### PR DESCRIPTION
This fixes https://github.com/galenguyer/nano-syntax-highlighting/issues/22

![image](https://github.com/galenguyer/nano-syntax-highlighting/assets/23246033/266cfa66-b3e1-4a2c-b5ad-8fab46781670)
