### PR TITLE
enh(php): Tidy up regex rules

### DIFF
--- a/php.nanorc
+++ b/php.nanorc
@@ -3,19 +3,22 @@ syntax "PHP" "\.php[2345s~]?$|\.module$"
 header "^#!.*php"
 magic "PHP script"
 comment "//"
+
+# Default
 color white start="<\?(php|=)?" end="\?>"
 # Constructs
 color brightblue "(class|extends|goto) ([a-zA-Z0-9_]*)"
-color brightblue "[^a-z0-9_-]{1}(var|class|function|echo|case|break|default|exit|switch|if|else|elseif|endif|foreach|endforeach|@|while|public|private|protected|return|const|static|extends|as|array|require|include|require_once|include_once|define|do|continue|declare|goto|print|in|namespace|use)[^a-z0-9_-]{1}"
+color brightblue "\<(var|class|function|echo|case|break|default|exit|switch|if|else|elseif|endif|foreach|endforeach|@|while|public|private|protected|return|const|static|extends|as|array|require|include|require_once|include_once|define|do|continue|declare|goto|print|in|namespace|use)\>"
 color brightblue "[a-zA-Z0-9_]+:"
 # Variables
-color green "\$[a-zA-Z_0-9$]*|[=!<>]"
-color green "\->[a-zA-Z_0-9$]*|[=!<>]"
+#color green "\$[a-zA-Z_0-9]*|[=!<>]"
+#color green "\->[a-zA-Z_0-9$]*|[=!<>]"
+color green "\$[a-zA-Z_0-9]*"
+color green "\->[a-zA-Z_0-9]*"
 # Functions
 color brightblue "([a-zA-Z0-9_-]*)\("
 # Special values
-color brightmagenta "[^a-z0-9_-]{1}(true|false|null|TRUE|FALSE|NULL)$"
-color brightmagenta "[^a-z0-9_-]{1}(true|false|null|TRUE|FALSE|NULL)[^A-Za-z0-9_-]{1}"
+color brightmagenta "\<(true|false|null|TRUE|FALSE|NULL)\>"
 # Special Characters
 color yellow "[.,{}();]"
 color cyan "\["
@@ -30,26 +33,25 @@ color magenta ";"
 color yellow "(<|>)"
 # Assignment operator
 color brightblue "="
-# Bitwise Operations
+# Bitwise operators
 color magenta "(&|\||\^)"
 color magenta "(<<|>>)"
 # Comparison operators
 color yellow "(==|===|!=|<>|!==|<=|>=|<=>)"
 # Logical Operators
-color yellow "( and | or | xor |!|&&|\|\|)"
-# And/Or/SRO/etc
-color cyan "(\;\;|\|\||::|=>|->)"
+color yellow "\<(and|or|xor)\>" "(!|&&|\|\|)"
+# SRO and other operators
+color cyan "(\;\;|::|=>|->)"
 # Double quoted STRINGS!
-color red "(\"[^\"]*\")"
+color red "\"([^"\]|\\.)*\""
+# Single quoted string
+color red "'([^'\]|\\.)*'"
 # Heredoc (typically ends with a semicolon).
 color red start="<<<['\"]?[A-Z][A-Z0-9_]*['\"]?" end="^[A-Z][A-Z0-9_]*;"
 # Inline Variables
 color white "\{\$[^}]*\}"
-# Single quoted string
-color red "('[^']*')"
 # Online Comments
-color brightyellow "^(#.*|//.*)$"
-color brightyellow "[	| ](#.*|//.*)$"
+color brightyellow "(^|[[:blank:]])(#.*|//.*)$"
 # PHP Tags
 color red "(<\?(php)?|\?>)"
 # General HTML
@@ -58,5 +60,3 @@ color red start="\?>" end="<\?(php|=)?"
 color ,green "[[:space:]]+$"
 # multi-line comments
 color brightyellow start="/\*" end="\*/"
-# Nowdoc
-color red start="<<<'[A-Z][A-Z0-9_]*'" end="^[A-Z][A-Z0-9_]*;"

--- a/php.nanorc
+++ b/php.nanorc
@@ -11,7 +11,7 @@ color brightblue "(class|extends|goto) ([a-zA-Z0-9_]*)"
 color brightblue "\<(var|class|function|echo|case|break|default|exit|switch|if|else|elseif|endif|foreach|endforeach|@|while|public|private|protected|return|const|static|extends|as|array|require|include|require_once|include_once|define|do|continue|declare|goto|print|in|namespace|use)\>"
 color brightblue "[a-zA-Z0-9_]+:"
 # Variables
-#color green "\$[a-zA-Z_0-9]*|[=!<>]"
+#color green "\$[a-zA-Z_0-9$]*|[=!<>]"
 #color green "\->[a-zA-Z_0-9$]*|[=!<>]"
 color green "\$[a-zA-Z_0-9]*"
 color green "\->[a-zA-Z_0-9]*"
@@ -24,7 +24,7 @@ color yellow "[.,{}();]"
 color cyan "\["
 color cyan "\]"
 # Numbers
-color magenta "[+-]*([0-9]\.)*[0-9]+([eE][+-]?([0-9]\.)*[0-9])*"
+color magenta "\<[+-]?([0-9]*\.)?[0-9]+([eE][+-]?[0-9]+)?\>"
 color magenta "0x[0-9a-zA-Z]*"
 # Special Variables
 color brightblue "(\$this|parent::|self::|\$this->)"
@@ -47,7 +47,7 @@ color red "\"([^"\]|\\.)*\""
 # Single quoted string
 color red "'([^'\]|\\.)*'"
 # Heredoc (typically ends with a semicolon).
-color red start="<<<['\"]?[A-Z][A-Z0-9_]*['\"]?" end="^[A-Z][A-Z0-9_]*;"
+color red start="<<<[\"]?[A-Z][A-Z0-9_]*[\"]?" end="^[A-Z][A-Z0-9_]*;"
 # Inline Variables
 color white "\{\$[^}]*\}"
 # Online Comments
@@ -60,3 +60,5 @@ color red start="\?>" end="<\?(php|=)?"
 color ,green "[[:space:]]+$"
 # multi-line comments
 color brightyellow start="/\*" end="\*/"
+# Nowdoc
+color red start="<<<'[A-Z][A-Z0-9_]*'" end="^[A-Z][A-Z0-9_]*;"


### PR DESCRIPTION
## Why
I [once](https://github.com/scopatz/nanorc/pull/378) found rules like
```regex
[^a-z0-9_-]{1}(true|false)[^a-z0-9_-]{1}
```
Notice that it enclosed `(true|false)` by a pair of `[^a-z0-9_-]{1}`, whose purpose is to detect **word boundaries**. That is, `true` should not be part of another word. However, detecting boundaries by this is not clever and make things more complicated. It should use `\<` and `\>` [instead](https://www.gnu.org/software/findutils/manual/html_node/find_html/posix_002dextended-regular-expression-syntax.html).

## How
- Use `\<` and `\>` to match word boundaries, instead of `[^a-z0-9_-]{1}`
- Fix the OR operator `||` being highlighted twice.
- Fix cannot include escapes in quoted strings.
- Fix broken number highlighting, which caused variable names unable of containing digits.
  - eg. `$num123` in the screenshot
- Make inline comments regex more compact.
- Variables: Remove parts that does not seem relevant

## Before
<img src="https://github.com/galenguyer/nano-syntax-highlighting/assets/23246033/6a0dac1f-ccdf-4e7d-b39f-568dc9f58b17" width=80%>

## After
<img src="https://github.com/galenguyer/nano-syntax-highlighting/assets/23246033/7c950403-7939-4b71-8876-5e0c0050d3b8" width=80%>
