### PR TITLE
enh: specify `tabgives` for certain languages

### DIFF
--- a/go.nanorc
+++ b/go.nanorc
@@ -1,5 +1,6 @@
 syntax "GO" "\.go$"
 comment "//"
+tabgives "	"
 
 color brightblue "[A-Za-z_][A-Za-z0-9_]*[[:space:]]*[()]"
 color brightblue "\<(append|cap|close|complex|copy|delete|imag|len)\>"

--- a/makefile.nanorc
+++ b/makefile.nanorc
@@ -2,6 +2,7 @@ syntax "Makefile" "([Mm]akefile|\.ma?k)$"
 header "^#!.*/(env +)?[bg]?make( |$)"
 magic "makefile script"
 comment "#"
+tabgives "	"
 
 color cyan  "\<(ifeq|ifdef|ifneq|ifndef|else|endif)\>"
 color cyan  "^(export|include|override)\>"

--- a/prolog.nanorc
+++ b/prolog.nanorc
@@ -1,6 +1,6 @@
 ## Here is a prolog example.
 
-syntax "prolog" "\.pl$"
+syntax "prolog" "\.pl$" "\.pro$"
 comment "%"
 
 # Reset everything

--- a/verilog.nanorc
+++ b/verilog.nanorc
@@ -18,7 +18,7 @@
 # a starting point. I based verilog.nanorc off of c.nanorc and
 # python.nanorc.
 
-syntax "verilog" "\.(v|vh|sv|svh)$"
+syntax "verilog" "\.(v|vh|vlg|verilog|sv|svh)$"
 
 # I don't think we want this.
 #color brightred "\<[A-Z_][0-9A-Z_]+\>"

--- a/yaml.nanorc
+++ b/yaml.nanorc
@@ -1,6 +1,7 @@
 syntax "yaml" "\.ya?ml$"
 #comment "#"
 header "^---" "%YAML"
+tabgives "  "
 
 # Values
 color green "(:|^|\s)+\S+"


### PR DESCRIPTION
- Makefile: Tabs
- Go: Tabs
- Yaml: Two spaces
- Add extension:
  - Prolog: `.pro`
  - Verilog: `.vlg` `.verilog`