### PR TITLE
fix(jade): conditional comment range issue

### DIFF
--- a/jade.nanorc
+++ b/jade.nanorc
@@ -33,8 +33,7 @@ color ,green "[[:space:]]+$"
 # Unbuffered comments
 color brightblue "\s+(//-.*)"
 # HTML-style conditional comments
-color brightmagenta start="<!" end="!>"
-color brightmagenta "<!\[endif\]-->"
+color brightmagenta start="<!(--)?\[if" end="<!\[endif\](--)?>"
 # HTML-style elements
 color yellow "<([^!].*)>"
 # Pipes


### PR DESCRIPTION
This fix #33

### Before
<img src="https://github.com/galenguyer/nano-syntax-highlighting/assets/23246033/ccfe1696-2e20-4ce3-83fe-57fee1b98666" width=80%>

### After
<img src="https://github.com/galenguyer/nano-syntax-highlighting/assets/23246033/70dfaf74-c5b6-4fb5-9f0e-9752e8391ce9" width=80%>
