### PR TITLE
enh(patch): Add diff header pattern

### DIFF
--- a/patch.nanorc
+++ b/patch.nanorc
@@ -1,6 +1,7 @@
 ## Here is an example for patch files.
 ##
 syntax "Patch" "\.(patch|diff)$"
+header "^diff\>"
 magic "diff output"
 # You can't add comments in patch files.
 comment ""


### PR DESCRIPTION
This is for files like `.rej` extension. The `.rej` files might be, for example, generated after applying a patch: `git apply --reject 0001-some-commit.patch`