### PR TITLE
enh: Fix shellcheck warnings

### DIFF
--- a/tool/include-list-gen.sh
+++ b/tool/include-list-gen.sh
@@ -1,9 +1,9 @@
 #!/bin/sh -e
 # Generate the content of nanorc
 
-base="$(dirname $0)/../"
+base="$(dirname "$0")/../"
 
 rm "$base/nanorc"
-for n in $base/*.nanorc; do
+for n in "$base"/*.nanorc; do
     printf 'include "~/.nano/%s"\n' "$(basename "$n")" >> "$base/nanorc"
 done

--- a/tool/shellcheck.sh
+++ b/tool/shellcheck.sh
@@ -1,5 +1,5 @@
 #!/bin/sh -ev
 # Shellcheck the script
 
-base="$(dirname $0)/../"
+base="$(dirname "$0")/../"
 shellcheck "$base/install.sh"


### PR DESCRIPTION
```
$ shellcheck tool/*

In tool/include-list-gen.sh line 4:
base="$(dirname $0)/../"
                ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
base="$(dirname "$0")/../"


In tool/include-list-gen.sh line 7:
for n in $base/*.nanorc; do
         ^---^ SC2231 (info): Quote expansions in this for loop glob to prevent wordsplitting, e.g. ">
ir"/*.txt .


In tool/shellcheck.sh line 4:
base="$(dirname $0)/../"
                ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
base="$(dirname "$0")/../"

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
  https://www.shellcheck.net/wiki/SC2231 -- Quote expansions in this for loop...

```