### PR TITLE
New tags for rpm specification files

### DIFF
--- a/rpmspec.nanorc
+++ b/rpmspec.nanorc
@@ -6,7 +6,7 @@ color cyan  "\<(Conflicts|Obsoletes|Provides|Requires|Requires\(.*\)|Enhances|Su
 color cyan  "\<(Epoch|Serial|Nosource|Nopatch):"
 color cyan  "\<(AutoReq|AutoProv|AutoReqProv):"
 color cyan  "\<(Copyright|License|Summary|Summary\(.*\)|Distribution|Vendor|Packager|Group|Source[0-9]*|Patch[0-9]*|BuildRoot|Prefix):"
-color cyan  "\<(Name|Version|Release|Url|URL):"
+color cyan  "\<(Name|Version|Release|Url|URL|Vcs|VCS):"
 color cyan  start="^(Source|Patch)" end=":"
 color cyan  "(i386|i486|i586|i686|athlon|ia64|alpha|alphaev5|alphaev56|alphapca56|alphaev6|alphaev67|sparc|sparcv9|sparc64armv3l|armv4b|armv4lm|ips|mipsel|ppc|ppc|iseries|ppcpseries|ppc64|m68k|m68kmint|Sgi|rs6000|i370|s390x|s390|noarch)"
 color cyan  "(ifarch|ifnarch|ifos|ifnos)"

--- a/rpmspec.nanorc
+++ b/rpmspec.nanorc
@@ -2,7 +2,7 @@ syntax "Rpmspec" "\.spec$" "\.rpmspec$"
 
 color cyan  "\<(Icon|ExclusiveOs|ExcludeOs):"
 color cyan  "\<(BuildArch|BuildArchitectures|ExclusiveArch|ExcludeArch):"
-color cyan  "\<(Conflicts|Obsoletes|Provides|Requires|Requires\(.*\)|Enhances|Suggests|BuildConflicts|BuildRequires|Recommends|PreReq|Supplements):"
+color cyan  "\<(Conflicts|Obsoletes|Provides|Requires|Requires\(.*\)|Enhances|Suggests|BuildConflicts|BuildRequires|BuildRequires\(.*\)|Recommends|PreReq|Supplements):"
 color cyan  "\<(Epoch|Serial|Nosource|Nopatch):"
 color cyan  "\<(AutoReq|AutoProv|AutoReqProv):"
 color cyan  "\<(Copyright|License|Summary|Summary\(.*\)|Distribution|Vendor|Packager|Group|Source[0-9]*|Patch[0-9]*|BuildRoot|Prefix):"


### PR DESCRIPTION
I am building packages for ALT Linux and here is a fork
of rpm with its own tags, which are probably only in this fork.
For example:
https://packages.altlinux.org/ru/sisyphus/srpms/python3-module-xonsh/specfiles/
https://packages.altlinux.org/ru/sisyphus/srpms/frei0r-plugins/specfiles/
https://packages.altlinux.org/ru/sisyphus/srpms/lua5.4-module-luacheck/specfiles/