### PR TITLE
fix(html): HTML should not be highlighted as XML

### DIFF
--- a/xml.nanorc
+++ b/xml.nanorc
@@ -1,7 +1,7 @@
 ## Here is an example for xml files.
 ##
 
-syntax "XML" ".*\.([jrs]?html?|xml|sgml?|rng|vue|mei|musicxml)$"
+syntax "XML" "\.([jrsx]html?|xml|sgml?|rng|vue|mei|musicxml)$"
 header "<\?xml.*version=.*\?>"
 magic "(XML|SGML) (sub)?document"
 comment "<!--|-->"


### PR DESCRIPTION
Currently, HTML are all highlighted as XML, which is not ideal because there is already a dedicated `html.nanorc` for HTML.
Also, the two syntax in the [upstream](https://git.savannah.gnu.org/cgit/nano.git/tree/syntax/xml.nanorc) are also separated.

**Before**
![image](https://github.com/user-attachments/assets/1e2cba59-cf18-470f-a2de-0155d30b05dc)

**After**
![image](https://github.com/user-attachments/assets/f733a694-9447-4e80-b12b-88858216900f)
