### PR TITLE
enh(c): Added higlighting for pragma, true, and false

### DIFF
--- a/c.nanorc
+++ b/c.nanorc
@@ -13,8 +13,9 @@ color green "\<((const|dynamic|reinterpret|static)_cast)\>"
 color green "\<(alignas|alignof|asm|auto|compl|concept|constexpr|decltype|export|noexcept|nullptr|requires|static_assert|thread_local|typeid|override|final)\>"
 color green "\<(and|and_eq|bitand|bitor|not|not_eq|or|or_eq|xor|xor_eq)\>"
 color brightmagenta "\<(goto|continue|break|return)\>"
-color brightcyan "^[[:space:]]*#[[:space:]]*(define|include|(un|ifn?)def|endif|el(if|se)|if|warning|error)"
+color brightcyan "^[[:space:]]*#[[:space:]]*(pragma|define|include|(un|ifn?)def|endif|el(if|se)|if|warning|error)"
 color brightmagenta "'([^'\]|(\\["'abfnrtv\\]))'" "'\\(([0-3]?[0-7]{1,2}))'" "'\\x[0-9A-Fa-f]{1,2}'"
+color orange "\<(true|false)\>"
 
 ##
 ## GCC builtins


### PR DESCRIPTION
Originally proposed in https://github.com/scopatz/nanorc/pull/431

## Before
![image](https://github.com/user-attachments/assets/678cfeb6-b1f8-4a0b-aaab-0c34ad8f364e)

## After
![image](https://github.com/user-attachments/assets/d913d4b9-9b83-434b-ab98-41f5ece81c5f)
