### PR TITLE
enh(CI): Automatic Release Workflow

### DIFF
--- a/.github/workflows/installer-sync.yml
+++ b/.github/workflows/installer-sync.yml
@@ -10,7 +10,7 @@ jobs:
   installer-sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
 
       - name: Check nanorc included every *nanorc files
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,95 @@
+name: release
+
+on:
+  schedule:
+    - cron: '0 0 1 */1 *' # @monthly
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        type: string
+        required: false
+      environment:
+        type: environment
+        required: true
+        default: release
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.verify.outputs.release_tag }}
+      release_commit: ${{ steps.verify.outputs.release_commit }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-tags: true
+          # FIXME: workaround for git 2.48, see https://github.com/actions/checkout/issues/1467
+          fetch-depth: 100
+          ref: ${{ github.ref }}
+
+      - name: Verify release tag
+        id: verify
+        env:
+          INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
+          REPOSITORY_URL: '${{ github.server_url }}/${{ github.repository }}'
+        run: |
+          set -eu
+
+          latest_tag="$(git describe --tags --abbrev=0)"
+          latest_tag_fmt="[\`${latest_tag}\`](${REPOSITORY_URL}/releases/tag/${latest_tag})"
+          release_tag="${INPUT_RELEASE_TAG:-$(date +'%Y.%m.%d')}"
+          release_commit="$(git log --format="%H" -n 1)"
+
+          # note: this comparison only works with lexicographic dates
+          if [[ ! "${release_tag}" > "${latest_tag}" ]]; then
+            echo "## Skipping release \`${release_tag}\`" >> "$GITHUB_STEP_SUMMARY"
+            echo "Latest tag ${latest_tag_fmt} already covers this date." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          elif [[ "$(git log --format="%H" -n 1 "${latest_tag}")" = "${release_commit}" ]]; then
+            echo "## Skipping release \`${release_tag}\`" >> "$GITHUB_STEP_SUMMARY"
+            echo "No changes since ${latest_tag_fmt}." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          {
+            echo "## Proposing new release \`${release_tag}\`"
+            echo "Commit: [${release_commit}](${REPOSITORY_URL}/commit/${release_commit})"
+
+            echo "### Changes since ${latest_tag_fmt}"
+            echo '```log'
+            git diff --histogram --stat "${latest_tag}..${release_commit}"
+            echo '```'
+
+            echo '### Git log'
+            echo '```log'
+            git log --no-merges "${latest_tag}..${release_commit}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "release_tag=${release_tag}" >> "$GITHUB_OUTPUT"
+          echo "release_commit=${release_commit}" >> "$GITHUB_OUTPUT"
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [verify]
+    if: needs.verify.outputs.release_tag != ''
+    environment: ${{ inputs.environment || 'release' }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.verify.outputs.release_commit }}
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.verify.outputs.release_tag }}
+          name: ${{ needs.verify.outputs.release_tag }}
+          target_commitish: ${{ needs.verify.outputs.release_commit }}
+          generate_release_notes: true
+          make_latest: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -10,22 +10,20 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
 
       - name: ShellCheck
-        uses: ludeeus/action-shellcheck@1.1.0
+        uses: ludeeus/action-shellcheck@2.0.0
         #with:
           # A space separated list of additional filename to check
-          #additional_files: # optional, default is 
+          #additional_files: # optional, default is ''
           # Paths to ignore when running ShellCheck
-          #ignore: # optional, default is 
+          #ignore_paths: # optional, default is ''
           # Minimum severity of errors to consider. Options: [error, warning, info, style]
-          #severity: # optional, default is 
+          #severity: # optional, default is ''
           # Run shellcheck on _all_ files at once, instead of one at a time
-          #check_together: # optional, default is 
+          #check_together: # optional, default is ''
           # Directory to be searched for files. Defaults to .
           #scandir: # optional, default is .
-          # Set to true to skip using problem-matcher
-          #disable_matcher: # optional, default is false
           # Output format (checkstyle, diff, gcc, json, json1, quiet, tty)
           #format: # optional, default is gcc


### PR DESCRIPTION
<!-- enh(CI): Automatic Release Workflow -->

# Automatic Release Workflow

This PR introduces a `release` workflow that runs on the first day of every month, checks for changes on `master` and, if so, creates a new release after approval.

- Closes #57

## Tag Selection

The `verify` job selects a tag name with format `%Y.%m.%d` (e.g. `2025.08.01`), which always ends in `01` since it runs on the first day of each month. If the tag is newer than the previous one and there are changes in `master`, then the workflow generates a change summary and continues to the `release` job, which requests a review and awaits for approval.

*The examples below use format `%Y.%m.%d-%H` for faster (test) release cycles, but everything else is the same.*

### Summary

The summary is generated with `git diff --histogram --stat $latest_tag..$release_commit` and `git log --no-merges $latest_tag..$release_commit`, so merge commits are not displayed.

To prevent new commits from being integrated into the release without showing up on the summary, the `verify` job also provides the `release_commit` used.

<details><summary><b>Release Summary</b></summary>

````md
## Proposing new release `2025.07.14-05`
### Changes since [`2025.07.13-23`](https://github.com/marmitar/nano-syntax-highlighting/releases/tag/2025.07.13-23)
```log
 git.nanorc | 17 ++++++++---------
 readme.md  |  7 +++----
 2 files changed, 11 insertions(+), 13 deletions(-)
```
### Git log
```log
commit ce788aa4e727ea09e542c8b91e59574645dc75a0
Author: Tiago de Paula <tiagodepalves@gmail.com>
Date:   Sun Jul 13 23:32:45 2025 -0300

    enh(gitcommit): improve colors for kitty+fish combo

commit 22592a37ddc9639b206f4c6e5859d4421348b4dd
Author: Tiago de Paula <tiagodepalves@gmail.com>
Date:   Sun Jul 13 23:24:01 2025 -0300

    chore(readme): add release badge

commit dd9e3ca50d430f6ffc1b8c4d79af76e37b52f754
Author: Tiago de Paula <tiagodepalves@gmail.com>
Date:   Sun Jul 13 23:17:13 2025 -0300

    chore(readme): restore package manager information
```
````

---

![message-ok](https://github.com/user-attachments/assets/81142ded-cb8a-438f-96b7-68be3d573291)

</details>

- Examples: [#30](https://github.com/marmitar/nano-syntax-highlighting/actions/runs/16254545342), [#35](https://github.com/marmitar/nano-syntax-highlighting/actions/runs/16258745959), [#37](https://github.com/marmitar/nano-syntax-highlighting/actions/runs/16260703509)

### Checks

Each tag is checked to be newer using lexicographical order, which works for `%Y.%m.%d`. Just be aware of any additional text after the date. For example, `2025.07.01-2` is considered newer than `2025.07.01-10`.

After that, the last commit on `master` is compared to the `$latest_tag`, and the release is skipped if no change is reported.

In both cases, skipping the relase is not considered a failure. The workflow just finishes early and no notification is sent anywhere.

<details><summary><b>Outdated Release</b></summary>

````md
## Skipping release `2025.07.13-23`
Latest tag [`2025.07.13-23`](https://github.com/marmitar/nano-syntax-highlighting/releases/tag/2025.07.13-23) already covers this date.
````

---

![message-outdated](https://github.com/user-attachments/assets/459b8d78-fcb1-4698-98cb-d2bf7e387787)

</details>

<details><summary><b>Release with No Changes</b></summary>

````md
## Skipping release `2025.07.14-02`
No changes since [`2025.07.13-23`](https://github.com/marmitar/nano-syntax-highlighting/releases/tag/2025.07.13-23).
````

---

![message-no-changes](https://github.com/user-attachments/assets/f3c4429a-baea-47e8-b378-b4ef287b7f82)

</details>

- Examples: [#31](https://github.com/marmitar/nano-syntax-highlighting/actions/runs/16256097841), [#32](https://github.com/marmitar/nano-syntax-highlighting/actions/runs/16256116191), [#33](https://github.com/marmitar/nano-syntax-highlighting/actions/runs/16256260221), [#36](https://github.com/marmitar/nano-syntax-highlighting/actions/runs/16259810098)

### Manual Release

The job can also be triggered manually on [Actions page](https://github.com/galenguyer/nano-syntax-highlighting/actions/workflows/release.yml), with an optional `release_tag` different from `%Y.%m.%d`. You can also change the [deploy `environment`](#github-environment) for this manual run.

![manual-options](https://github.com/user-attachments/assets/45a5eb0f-d7f9-4dd8-8a05-52d126715cbe)

<details><summary><b>Full Page</b></summary>

![message-release](https://github.com/user-attachments/assets/394ade6d-e5d6-4759-b5e5-640e598c373c)

</details>

## Workflow Review

Once `verify` completes with a non-empty `release_tag`, the workflow request reviews from defined members before starting the `release` job.

The `release` job pins the release to exact `$release_commit` provided by `verify`, independently of how long the review process take. Once a release is verified, its commit is fixed. To include newer commits you must cancel and rerun the workflow.

<details><summary>Release Verified, Awaiting Review</summary>

![release-verified](https://github.com/user-attachments/assets/25a0cd7f-ce0e-4729-936e-3e6157fe1d10)

</details>

<details><summary>Review Notification Sent to Email</summary>

![release-review-request](https://github.com/user-attachments/assets/e2653a43-9da0-4a92-bfa3-b14070cb65a1)

</details>

<details><summary>Review Page</summary>

![release-review](https://github.com/user-attachments/assets/b7cd1f0e-6364-4751-a72d-5ae2e7e64527)

</details>

<details><summary>Release Approved</summary>

![release-approved](https://github.com/user-attachments/assets/16058072-7563-488d-a7ae-e2679a399da2)

</details>

<details><summary>Release Created</summary>

![released](https://github.com/user-attachments/assets/48a5e30a-818e-4dd4-a864-bf2492d25c5f)

</details>

### GitHub Environment

> [!IMPORTANT]
> This step requires manual configuration in the repository Settings.

The review system uses [deploy environments on Github](https://docs.github.com/en/actions/how-tos/managing-workflow-runs-and-deployments/managing-deployments/managing-environments-for-deployment). The workflow doesn't actually use any information from the environment, but if the environment is configured with "Required reviewers", then it won't run by itself. Here I used `release` as the name of the environment.

<details><summary><b>Environment Settings</b></summary>

![released](https://github.com/user-attachments/assets/6ffa8b33-50ad-438f-9854-ea1282ca259a)

</details>

### Job Concurrency

To avoid multiple competing releases, I've set up a `concurrency` `group` that disallows concurrent runs of the `release.yml` workflow. If a new workflow starts while the last one is still running, then the new one has priority and the other is cancelled. In practice, this should only happen if a release is left unapproved for more than a month.

<details><summary><b>Unapproved Release</b></summary>

![released](https://github.com/user-attachments/assets/86ec04a6-b9a1-495b-befc-afd7a75908a0)

</details>

- Example: [#24](https://github.com/marmitar/nano-syntax-highlighting/actions/runs/16251594856), [#25](https://github.com/marmitar/nano-syntax-highlighting/actions/runs/16252200601), [#26](https://github.com/marmitar/nano-syntax-highlighting/actions/runs/16252593840), [#27](https://github.com/marmitar/nano-syntax-highlighting/actions/runs/16253110094), [#28](https://github.com/marmitar/nano-syntax-highlighting/actions/runs/16253570186), [#29](https://github.com/marmitar/nano-syntax-highlighting/actions/runs/16254058395)

## Release Creation

Once the `release` job is approved and runs, it creates a tag with the name `$release_tag` provided by `verify`, pointing to the pinned `$release_commit`. It also creates a [GitHub release](https://github.com/galenguyer/nano-syntax-highlighting/releases) with [automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes), which can be configured in a `.github/release.yml` file. By default, the generated notes list all pull requests since the last release (which might be a lot for the first one here, you can create a first release to avoid this).

<details><summary><b>Changelog Example</b></summary>

![Release `2025.07.14-05`](https://github.com/user-attachments/assets/10d0a435-8050-4f57-8b2c-6462ff6b8829)

![Release `2025.07.14-07`](https://github.com/user-attachments/assets/0c753175-19e5-4aa2-8659-cb8ca93e2e42)

</details>

- Examples: [2025.07.13-23](https://github.com/marmitar/nano-syntax-highlighting/releases/tag/2025.07.13-23), [2025.07.14-05](https://github.com/marmitar/nano-syntax-highlighting/releases/tag/2025.07.14-05), [2025.07.14-07](https://github.com/marmitar/nano-syntax-highlighting/releases/tag/2025.07.14-07)

## Implementation Notes

There's currently an issue (actions/checkout#1467) with `fetch_tags` on Git 2.48 (`ubunut-latest`), which requires explicit fetching of the git history using `fetch-depth` and `ref`. I used the last 100 commits for `fetch-depth`, which should be more than enough for a month. The workaround implemented here can be removed after the fix actions/checkout#2200 lands.