### PR TITLE
Add 'AS' keyword to Dockerfile

### DIFF
--- a/Dockerfile.nanorc
+++ b/Dockerfile.nanorc
@@ -1,7 +1,11 @@
 ## Syntax highlighting for Dockerfiles
 syntax "Dockerfile" "Dockerfile[^/]*$" "\.dockerfile$"
 
-## Keywords
+## AS keyword
+icolor red start="^FROM[[:space:]]" end="([[:space:]]AS[[:space:]]|$)"
+icolor white "^FROM[[:space:]]*[^[:space:]]+[[:space:]]*"
+
+## Other keywords
 icolor red "^(FROM|RUN|CMD|LABEL|MAINTAINER|EXPOSE|ENV|ADD|COPY|ENTRYPOINT|VOLUME|USER|WORKDIR|ARG|ONBUILD|STOPSIGNAL|HEALTHCHECK|SHELL)[[:space:]]"
 
 ## Brackets & parenthesis


### PR DESCRIPTION
This change adds a new highlighted keyword -- `AS`. This keyword will only be highlighted when used with the `FROM` keyword to denote a name for a Dockerfile build stage. Example usage:

```dockerfile
FROM image:tag AS stage_name
```

The implementation works around regex limitations to first highlight the whole line up until and including `AS` and then resets the highlighting for everything except it.