### PR TITLE
fix(nanorc): extendsyntax, set and black invisible

### DIFF
--- a/nanorc.nanorc
+++ b/nanorc.nanorc
@@ -7,14 +7,14 @@ comment "#"
 color brightred "^[[:space:]]*((un)?set|include|syntax|i?color).*$"
 
 ## Basic colors
-color red       "\<red\>"
-color green     "\<green\>"
-color blue      "\<blue\>"
-color magenta   "\<magenta\>"
-color yellow    "\<yellow\>"
-color cyan      "\<cyan\>"
-color white     "\<white\>"
-color black     "\<black\>"
+color red           "\<red\>"
+color green         "\<green\>"
+color blue          "\<blue\>"
+color magenta       "\<magenta\>"
+color yellow        "\<yellow\>"
+color cyan          "\<cyan\>"
+color white         "\<white\>"
+color lightblack    "\<black\>"
 ## Light/bright colors
 color lightred          "\<(light|bright)red\>"
 color lightgreen        "\<(light|bright)green\>"
@@ -52,15 +52,15 @@ color normal    "\<normal\>"
 ## hex color
 color green     "#[0-9][0-9][0-9]"
 
-## Keywords
-color green "^[[:space:]]*(set|unset|syntax|header|magic|formatter|linter|comment|tabgives|include|extendssyntax|bind|unbind)\>"
-color white "\<(bold|italic)\>" ","
-color magenta  "^[[:space:]]*i?color\>" "\<(start|end)="
-#color yellow   "^[[:space:]]*(set|unset)[[:space:]]+(errorcolor|functioncolor|keycolor|numbercolor|selectedcolor|statuscolor|stripecolor|titlecolor)[[:space:]]+(bright|light)?(white|black|red|blue|green|yellow|magenta|cyan|normal)?(,(white|black|red|blue|green|yellow|magenta|cyan|normal))?\>"
-
 ## Valid options
 ## run: arr=($(man nanorc | grep "    set " | awk '{print $2}')); echo "$(IFS='|'; echo "${arr[*]}")"
 color brightgreen "^[[:space:]]*(set|unset)[[:space:]]+(afterends|allow_insecure_backup|atblanks|autoindent|backup|backupdir|boldtext|bookstyle|brackets|breaklonglines|casesensitive|constantshow|cutfromcursor|emptyline|errorcolor|fill|functioncolor|guidestripe|historylog|indicator|jumpyscrolling|keycolor|linenumbers|locking|magic|matchbrackets|minibar|minicolor|mouse|multibuffer|noconvert|nohelp|nonewlines|nowrap|numbercolor|operatingdir|positionlog|preserve|promptcolor|punct|quickblank|quotestr|rawsequences|rebinddelete|regexp|saveonexit|scrollercolor|selectedcolor|showcursor|smarthome|softwrap|speller|spotlightcolor|stateflags|statuscolor|stripecolor|tabsize|tabstospaces|titlecolor|trimblanks|unix|whitespace|wordbounds|wordchars|zap|zero)\>"
+
+## Keywords
+color green "^[[:space:]]*(set|unset|syntax|header|magic|formatter|linter|comment|tabgives|include|extendsyntax|bind|unbind)\>"
+color white "\<(bold|italic)\>" ","
+color magenta  "^[[:space:]]*i?color\>" "\<(start|end)="
+#color yellow   "^[[:space:]]*(set|unset)[[:space:]]+(errorcolor|functioncolor|keycolor|numbercolor|selectedcolor|statuscolor|stripecolor|titlecolor)[[:space:]]+(bright|light)?(white|black|red|blue|green|yellow|magenta|cyan|normal)?(,(white|black|red|blue|green|yellow|magenta|cyan|normal))?\>"
 
 ## Strings
 #icolor white ""([^"]|\\.)*""


### PR DESCRIPTION
this fix #60

<img width="569" height="174" alt="image" src="https://github.com/user-attachments/assets/24a4e29d-8f2c-4663-a798-f8691a8a1125" />