### PR TITLE
feat(install): fall back to curl when wget is not installed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,12 +7,32 @@ if [ ! "$(command -v unzip)" ]; then
   exit 1
 fi
 
+# check for a download tool; prefer wget, fall back to curl
+if command -v wget >/dev/null 2>&1; then
+  DOWNLOADER="wget"
+elif command -v curl >/dev/null 2>&1; then
+  DOWNLOADER="curl"
+else
+  echo 'Either wget or curl is required but neither was found. Install one of them and then run this script again.' >&2
+  exit 1
+fi
+
+# download URL into FILE using whichever tool is available
+_download() {
+  out="$1"
+  url="$2"
+  case "$DOWNLOADER" in
+    wget) wget -O "$out" "$url" ;;
+    curl) curl -fL -o "$out" "$url" ;;
+  esac
+}
+
 _fetch_sources() {
   br=$(_find_suitable_branch)
   mkdir -p ~/.nano/
   cd ~/.nano/
 
-  wget -O "/tmp/nanorc.zip" "https://github.com/galenguyer/nano-syntax-highlighting/archive/${br}.zip"
+  _download "/tmp/nanorc.zip" "https://github.com/galenguyer/nano-syntax-highlighting/archive/${br}.zip"
   unzip -o "/tmp/nanorc.zip"
   mv "nano-syntax-highlighting-${br}"/* ./
   rm -rf "nano-syntax-highlighting-${br}"

--- a/tool/test-install.sh
+++ b/tool/test-install.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Exercise install.sh in an isolated $HOME with a minimal $PATH so we can
+# verify the wget/curl detection logic (and the unzip guard) without
+# touching the real ~/.nanorc or ~/.nano.
+#
+# Use bash, not zsh: this is a bash script and should be invoked as
+#   ./tool/test-install.sh
+# (the shebang picks the right interpreter). Pasting the body into an
+# interactive zsh session will break on `#` comments and `(...)` tokens
+# because zsh treats those as glob qualifiers unless `interactive_comments`
+# is set.
+#
+# Usage:
+#   tool/test-install.sh [-l|--lite] [--keep] [--quiet]
+#     -l, --lite   pass -l through to install.sh
+#     --keep       keep the temp $HOME and $PATH dirs for post-mortem
+#     --quiet      suppress install.sh stdout/stderr (still shows exit code
+#                  and resulting .nanorc)
+
+set -u
+
+INSTALL_ARGS=()
+KEEP=0
+QUIET=0
+for arg in "$@"; do
+  case "$arg" in
+    -l|--lite) INSTALL_ARGS+=("-l") ;;
+    --keep)    KEEP=1 ;;
+    --quiet)   QUIET=1 ;;
+    -h|--help)
+      sed -n '2,19p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+BASE="$(cd "$(dirname "$0")/.." && pwd)"
+INSTALL="$BASE/install.sh"
+
+if [[ ! -x "$INSTALL" ]]; then
+  echo "cannot find executable install.sh at $INSTALL" >&2
+  exit 1
+fi
+
+# Build a minimal bin dir with everything install.sh needs EXCEPT wget/curl.
+# We toggle wget/curl in and out per scenario by adding/removing symlinks.
+TESTBIN=$(mktemp -d -t nanorc-testbin.XXXXXX)
+for t in bash sh awk grep sed unzip mkdir mv rm rmdir touch cp ln cat echo \
+         dirname basename nano tr cut head tail env mktemp printf chmod; do
+  src=$(command -v "$t" 2>/dev/null) || continue
+  ln -sf "$src" "$TESTBIN/$t"
+done
+
+HOMES=()
+
+cleanup() {
+  if (( KEEP )); then
+    echo
+    echo "KEEP: leaving TESTBIN=$TESTBIN"
+    for h in "${HOMES[@]}"; do echo "KEEP: leaving HOME=$h"; done
+  else
+    rm -rf "$TESTBIN"
+    for h in "${HOMES[@]}"; do rm -rf "$h"; done
+  fi
+}
+trap cleanup EXIT
+
+FAIL=0
+
+run_scenario() {
+  local label="$1" expect="$2"
+  local home
+  home=$(mktemp -d -t nanorc-home.XXXXXX)
+  HOMES+=("$home")
+
+  echo
+  echo "=============================================================="
+  echo "  $label   (expect exit $expect)"
+  echo "=============================================================="
+
+  local rc
+  if (( QUIET )); then
+    HOME="$home" PATH="$TESTBIN" bash "$INSTALL" "${INSTALL_ARGS[@]}" \
+      >/dev/null 2>&1
+    rc=$?
+  else
+    HOME="$home" PATH="$TESTBIN" bash "$INSTALL" "${INSTALL_ARGS[@]}"
+    rc=$?
+  fi
+
+  echo "--- exit=$rc ---"
+  if [[ -f "$home/.nanorc" ]]; then
+    echo "--- resulting \$HOME/.nanorc has $(wc -l <"$home/.nanorc" | tr -d ' ') lines ---"
+  else
+    echo "--- no \$HOME/.nanorc written ---"
+  fi
+
+  if [[ "$rc" -ne "$expect" ]]; then
+    echo "FAIL: $label expected exit $expect, got $rc" >&2
+    FAIL=1
+  fi
+}
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# 1. Missing unzip (early guard at the top of install.sh).
+rm -f "$TESTBIN/unzip"
+run_scenario "no unzip" 1
+have unzip && ln -sf "$(command -v unzip)" "$TESTBIN/unzip"
+
+# 2. Neither wget nor curl.
+rm -f "$TESTBIN/wget" "$TESTBIN/curl"
+run_scenario "no wget, no curl" 1
+
+# 3. curl only.
+if have curl; then
+  ln -sf "$(command -v curl)" "$TESTBIN/curl"
+  run_scenario "curl only" 0
+else
+  echo "SKIP: curl not installed on this host"
+fi
+
+# 4. wget only.
+rm -f "$TESTBIN/curl"
+if have wget; then
+  ln -sf "$(command -v wget)" "$TESTBIN/wget"
+  run_scenario "wget only" 0
+else
+  echo "SKIP: wget not installed on this host; can't exercise wget-only path"
+fi
+
+# 5. Both present. install.sh prefers wget.
+have curl && ln -sf "$(command -v curl)" "$TESTBIN/curl"
+have wget && ln -sf "$(command -v wget)" "$TESTBIN/wget"
+if have wget && have curl; then
+  run_scenario "both (wget preferred)" 0
+else
+  echo "SKIP: need both wget and curl for the 'both' scenario"
+fi
+
+echo
+if (( FAIL )); then
+  echo "RESULT: at least one scenario failed"
+  exit 1
+fi
+echo "RESULT: all scenarios passed"


### PR DESCRIPTION
## Summary

`install.sh` previously hard-required `wget`. On hosts where only `curl` is available (notably macOS out of the box) the script would fail as soon as it tried to fetch the syntax archive. This MR adds a lightweight downloader abstraction that prefers `wget` and falls back to `curl`, and ships a test harness that exercises the detection logic in an isolated environment.

## Changes

**`install.sh`**

- Added a pre-flight check that picks a downloader: `wget` if available, otherwise `curl`. If neither is present, the script fails fast with a clear message that mirrors the existing `unzip` guard.
- Extracted the download step into a `_download` helper so the rest of the script doesn't care which tool is used. `curl` is invoked with `-fL` so it fails on HTTP errors and follows redirects (GitHub's archive URL redirects to codeload).
- `wget` remains the preferred tool, so behaviour on existing Linux installs is unchanged.

**`tool/test-install.sh`** (new)

- Sandboxes every run by pointing `$HOME` at `mktemp -d`, so neither `~/.nanorc` nor `~/.nano` on the tester's machine is ever modified.
- Sandboxes tool discovery by pointing `$PATH` at a temp `$TESTBIN` that contains only the utilities `install.sh` needs. `wget` and `curl` symlinks are added/removed per scenario, which is the only reliable way to fool `command -v` (shell aliases and functions can't — `command -v` reports functions as valid and aliases don't expand in non-interactive bash).
- Scenarios, each asserting an expected exit code and dumping the resulting `.nanorc`:
  1. `no unzip` → expect exit 1 (pre-existing guard).
  2. `no wget, no curl` → expect exit 1 (new guard).
  3. `curl only` → expect exit 0, installs via curl.
  4. `wget only` → expect exit 0, installs via wget (skipped if host lacks wget).
  5. `both (wget preferred)` → expect exit 0, installs via wget.
- Flags: `-l/--lite` (pass through to `install.sh`), `--quiet` (silence install output), `--keep` (retain temp dirs for post-mortem).
- Suitable for local verification and for wiring into CI alongside the existing `tool/shellcheck.sh`.


## Testing

- `./tool/shellcheck.sh` — clean.
- `./tool/test-install.sh` — all five scenarios pass on macOS with both `wget` and `curl` installed.
- `./tool/test-install.sh --quiet` — same, summarized.
- `./tool/test-install.sh -l` — `--lite` codepath exits 0 in the downloader-present scenarios.
- Confirmed real `~/.nanorc` and `~/.nano/` are untouched after a full run (`ls -la ~/.nanorc ~/.nano 2>&1`).

## Risk / compatibility

- No behaviour change on hosts that already have `wget` installed — it remains preferred.
- New dependency surface is opt-in: `curl` is only invoked if `wget` is absent.
- `curl -fL` differs from `wget -O` in that it requires `-f` to treat 4xx/5xx as failure; this is set explicitly so a bad URL won't silently produce an HTML error page as the "zip".
