### PR TITLE
Add csproj and slnx to xml highlighting

### DIFF
--- a/xml.nanorc
+++ b/xml.nanorc
@@ -1,7 +1,7 @@
 ## Here is an example for xml files.
 ##
 
-syntax "XML" "\.([jrsx]html?|xml|sgml?|rng|vue|mei|musicxml)$"
+syntax "XML" "\.([jrsx]html?|xml|sgml?|rng|vue|mei|musicxml|csproj|slnx)$"
 header "<\?xml.*version=.*\?>"
 magic "(XML|SGML) (sub)?document"
 comment "<!--|-->"


### PR DESCRIPTION
I wanted to quickly check the csproj of a project I'm working on and realized csproj & slnx files were not supported so I added them.