### PR TITLE
Fix: Auto-detect curl or wget in install script and update README instructions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,12 +7,26 @@ if [ ! "$(command -v unzip)" ]; then
   exit 1
 fi
 
+_download_file() {
+  url="$1"
+  output="$2"
+
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$url" -o "$output"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q -O "$output" "$url"
+  else
+    echo 'Neither curl nor wget was found. Install one of them to proceed.' >&2
+    exit 1
+  fi
+}
+
 _fetch_sources() {
   br=$(_find_suitable_branch)
   mkdir -p ~/.nano/
   cd ~/.nano/
 
-  wget -O "/tmp/nanorc.zip" "https://github.com/galenguyer/nano-syntax-highlighting/archive/${br}.zip"
+  _download_file "https://github.com/galenguyer/nano-syntax-highlighting/archive/${br}.zip" "/tmp/nanorc.zip"
   unzip -o "/tmp/nanorc.zip"
   mv "nano-syntax-highlighting-${br}"/* ./
   rm -rf "nano-syntax-highlighting-${br}"
@@ -20,7 +34,7 @@ _fetch_sources() {
 }
 
 _update_nanorc() {
-  touch $NANORC_FILE
+  touch "$NANORC_FILE"
   # add all includes from ~/.nano/nanorc if they're not already there
   while read -r inc; do
       if ! grep -q "$inc" "${NANORC_FILE}"; then

--- a/readme.md
+++ b/readme.md
@@ -13,13 +13,13 @@ There are three ways to install this repo.
 
 ### 1. Automatic installer
 
-Copy the following code to download and run the installer script:
+Use this command in your terminal to automatically install using `curl`:
 
 ```sh
 curl https://raw.githubusercontent.com/galenguyer/nano-syntax-highlighting/master/install.sh | bash
 ```
 
-If your machine doesn't have `curl` command, use this code:
+You can also use `wget` if you do not have `curl` installed:
 
 ```sh
 wget https://raw.githubusercontent.com/galenguyer/nano-syntax-highlighting/master/install.sh -O- | bash


### PR DESCRIPTION
## Description
This PR addresses an issue where `install.sh` failed on environments lacking `wget` (such as macOS, Git Bash on Windows, or minimal containers). The script previously hardcoded `wget` internally to fetch the source zip, causing failures even when initiated via `curl`.

## Changes Made
- **`install.sh`**: Added a `_download_file` helper function using `command -v` to detect and use `curl` or `wget` dynamically. Added an explicit error message if neither is found.
- **`readme.md`**: Refactored the "Automatic installer" section to specify `curl` as the primary installation command and `wget` as the alternative fallback option.
